### PR TITLE
add run depend

### DIFF
--- a/kuka_arm/package.xml
+++ b/kuka_arm/package.xml
@@ -58,6 +58,7 @@
   <run_depend>gazebo_ros_control</run_depend>
   <run_depend>interactive_markers</run_depend>
   <run_depend>joint_state_publisher</run_depend>
+  <run_depend>joint_state_controller</run_depend>
   <run_depend>joint_trajectory_controller</run_depend>
   <run_depend>message_runtime</run_depend>
   <run_depend>moveit_core</run_depend>


### PR DESCRIPTION
type:fix
joint_state_controller is one of run dependencies. A local ubuntu+ros system might not have this package.