### PR TITLE
fix:  core dump in some Ubuntu 16.04 systems

### DIFF
--- a/kuka_arm/include/kuka_arm/trajectory_sampler.h
+++ b/kuka_arm/include/kuka_arm/trajectory_sampler.h
@@ -71,7 +71,7 @@ private:
   bool OpenGripper();
   bool CloseGripper();
 
-  bool SetupCollisionObject(const std::string &object_id,
+  void SetupCollisionObject(const std::string &object_id,
                             const std::string &mesh_path,
                             const geometry_msgs::Pose &object_pose,
                             moveit_msgs::CollisionObject &collision_object);

--- a/kuka_arm/src/trajectory_sampler.cpp
+++ b/kuka_arm/src/trajectory_sampler.cpp
@@ -558,7 +558,7 @@ bool TrajectorySampler::CloseGripper()
   return success;
 }
 
-bool TrajectorySampler::SetupCollisionObject(const std::string &object_id,
+void TrajectorySampler::SetupCollisionObject(const std::string &object_id,
     const std::string &mesh_path,
     const geometry_msgs::Pose &object_pose,
     moveit_msgs::CollisionObject &collision_object)


### PR DESCRIPTION
In some systems the non-void function SetupCollisionObject in trajectory_sampler.cpp causes a  Illegal instruction (core dumped) error. This fix replaces the declaration of the function from bool to void, allowing trajectory_sampler to run without crashing.

