### PR TITLE
Fix small notation error in DH Table.

### DIFF
--- a/writeup_template.md
+++ b/writeup_template.md
@@ -40,7 +40,7 @@ Here is an example of how to include an image in your writeup.
 
 #### 2. Using the DH parameter table you derived earlier, create individual transformation matrices about each joint. In addition, also generate a generalized homogeneous transform between base_link and gripper_link using only end-effector(gripper) pose.
 
-Links | alpha(i-1) | a(i-1) | d(i-1) | theta(i)
+Links | alpha(i-1) | a(i-1) | d(i) | theta(i)
 --- | --- | --- | --- | ---
 0->1 | 0 | 0 | L1 | qi
 1->2 | - pi/2 | L2 | 0 | -pi/2 + q2


### PR DESCRIPTION
Starting at 2:32 of KR210 Forward Kinematics 1 video "d(i) is the distance from X(i-1) to X(i) measured along the Z(i) axis." Therefore the distance from Link 0->1 is d(i), not d(i-1). alpha(i-1) and a(i-1) terms are correct as they measure from (i-1) to (i).