### PR TITLE
Fix compilation error due to missing bool cast operator for MoveItErr…

### DIFF
--- a/kuka_arm/src/trajectory_sampler.cpp
+++ b/kuka_arm/src/trajectory_sampler.cpp
@@ -177,7 +177,7 @@ TrajectorySampler::TrajectorySampler(ros::NodeHandle nh)
     // define plan object which will hold the planned trajectory
     moveit::planning_interface::MoveGroupInterface::Plan my_plan;
 
-    bool success = move_group.plan(my_plan);
+    bool success = static_cast<bool>(move_group.plan(my_plan));
     ROS_INFO("Visualizing plan to target: %s",
              success ? "SUCCEEDED" : "FAILED");
 
@@ -221,7 +221,7 @@ TrajectorySampler::TrajectorySampler(ros::NodeHandle nh)
                                rviz_visual_tools::WHITE, rviz_visual_tools::XXXXLARGE);
       visual_tools.trigger();
       // command the robot to execute the created plan
-      success = move_group.execute(my_plan);
+      success = static_cast<bool>(move_group.execute(my_plan));
       ROS_INFO("Moving to pick location: %s",
                success ? "SUCCEEDED" : "FAILED");
     }
@@ -288,7 +288,7 @@ TrajectorySampler::TrajectorySampler(ros::NodeHandle nh)
         }
 
         move_group.setJointValueTarget(robot_joint_positions);
-        bool worked = move_group.move();
+        bool worked = static_cast<bool>(move_group.move());
         ROS_INFO("Robot actuation: %s", worked ? "SUCCEEDED" : "FAILED");
       }
     }
@@ -310,7 +310,7 @@ TrajectorySampler::TrajectorySampler(ros::NodeHandle nh)
 
     move_group.setStartStateToCurrentState();
     move_group.setPoseTarget(target_reach);
-    success = move_group.move();
+    success = static_cast<bool>(move_group.move());
     ROS_INFO("Target reach: %s",
              success ? "SUCCEEDED" : "FAILED");
 
@@ -336,7 +336,7 @@ TrajectorySampler::TrajectorySampler(ros::NodeHandle nh)
     visual_tools.trigger();
     move_group.setStartStateToCurrentState();
     move_group.setPoseTarget(target_pose);
-    success = move_group.move();
+    success = static_cast<bool>(move_group.move());
     ROS_INFO("Target retrieval: %s",
              success ? "SUCCEEDED" : "FAILED");
 
@@ -348,7 +348,7 @@ TrajectorySampler::TrajectorySampler(ros::NodeHandle nh)
     move_group.setStartStateToCurrentState();
     move_group.setPoseTarget(bin_pose);
 
-    success = move_group.plan(my_plan);
+    success = static_cast<bool>(move_group.plan(my_plan));
     ROS_INFO("Visualizing plan to drop location: %s",
              success ? "SUCCEEDED" : "FAILED");
 
@@ -372,7 +372,7 @@ TrajectorySampler::TrajectorySampler(ros::NodeHandle nh)
                                rviz_visual_tools::WHITE, rviz_visual_tools::XXXXLARGE);
       visual_tools.trigger();
       // command the robot to execute the created plan
-      success = move_group.execute(my_plan);
+      success = static_cast<bool>(move_group.execute(my_plan));
       ROS_INFO("Moving to drop location: %s",
                success ? "SUCCEEDED" : "FAILED");
     }
@@ -449,7 +449,7 @@ TrajectorySampler::TrajectorySampler(ros::NodeHandle nh)
         }
 
         move_group.setJointValueTarget(robot_joint_positions);
-        bool worked = move_group.move();
+        bool worked = static_cast<bool>(move_group.move());
         ROS_INFO("Robot actuation: %s", worked ? "SUCCEEDED" : "FAILED");
       }
     }
@@ -494,7 +494,7 @@ TrajectorySampler::TrajectorySampler(ros::NodeHandle nh)
     }
 
     move_group.setJointValueTarget(robot_joint_positions);
-    success = move_group.move();
+    success = static_cast<bool>(move_group.move());
     ROS_INFO("Robot motion to Idle state: %s", success ? "SUCCEEDED" : "FAILED");
 
     // Spawn another target
@@ -540,7 +540,7 @@ bool TrajectorySampler::OperateGripper(const bool &close_gripper)
   eef_group.setJointValueTarget(gripper_joint_positions);
   ros::Duration(1.5).sleep();
 
-  bool success = eef_group.move();
+  bool success = static_cast<bool>(eef_group.move());
   return success;
 }
 


### PR DESCRIPTION
Fix compilation error due to missing bool cast operator for MoveItErrorCode::operator bool defined as explicit.

/home/mlotfy/catkin_ws/src/RoboND-Kinematics-Project/kuka_arm/src/trajectory_sampler.cpp: In constructor ‘TrajectorySampler::TrajectorySampler(ros::NodeHandle)’:
/home/mlotfy/catkin_ws/src/RoboND-Kinematics-Project/kuka_arm/src/trajectory_sampler.cpp:313:13: error: cannot convert ‘moveit::planning_interface::MoveItErrorCode’ to ‘bool’ in assignment
     success = move_group.move();
